### PR TITLE
fix(frontend): protect offer-ride and find-ride routes

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -34,8 +34,16 @@ function App() {
           </ProtectedRoute>
         } />
         
-        <Route path="/offer-ride" element={<OfferRide />} />
-        <Route path="/find-ride" element={<FindRide />} />
+        <Route path="/offer-ride" element={
+          <ProtectedRoute>
+            <OfferRide />
+          </ProtectedRoute>
+        } />
+        <Route path="/find-ride" element={
+          <ProtectedRoute>
+            <FindRide />
+          </ProtectedRoute>
+        } />
         
         <Route path="/how-it-works" element={<HowItWorks />} />
         <Route path="/safety" element={<Safety />} />


### PR DESCRIPTION
The offer-ride and find-ride routes were not protected, allowing unauthenticated users to access them. This would cause a flicker effect where the page would briefly render before redirecting you to the signin page.

This commit wraps the offer-ride and find-ride routes in the ProtectedRoute component to ensure that only authenticated users can access them. This fixes the flicker effect and makes the routing logic more consistent with other protected routes.